### PR TITLE
Update Gradle dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Below dependencies are automatically included when you add the Aurora DSQL JDBC 
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>dsql</artifactId>
-    <version>2.31.32</version>
+    <version>2.33.8</version>
 </dependency>
 ```
 
 Or in Gradle:
 ```kotlin
 implementation("org.postgresql:postgresql:42.7.7")
-implementation("software.amazon.awssdk:dsql:2.31.32")
+implementation("software.amazon.awssdk:dsql:2.33.8")
 ```
 
 ### What These Dependencies Provide

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("maven-publish")
     id("jacoco")
     id("com.github.spotbugs") version "6.3.+"
-    id("org.jreleaser") version "1.19.0"
+    id("org.jreleaser") version "1.20.0"
 }
 
 group = "software.amazon.dsql"
@@ -21,26 +21,24 @@ repositories {
 
 dependencies {
     // AWS SDK for Aurora DSQL
-    implementation("software.amazon.awssdk:dsql:2.31.32")
+    implementation("software.amazon.awssdk:dsql:2.33.8")
 
     // PostgreSQL JDBC Driver - core dependency for Aurora DSQL connector
     implementation("org.postgresql:postgresql:42.7.7")
 
     // Annotation dependencies for @Nullable, @Nonnull, etc.
-    implementation("javax.annotation:javax.annotation-api:1.3.2")
-    implementation("com.github.spotbugs:spotbugs-annotations:4.7.3")
+    implementation("com.github.spotbugs:spotbugs-annotations:4.9.4")
 
     // Test dependencies
     testImplementation("net.bytebuddy:byte-buddy-agent:1.17.7")
     testImplementation("net.bytebuddy:byte-buddy:1.17.7")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.2")
-    testImplementation("software.amazon.awssdk:regions:2.31.32")
-    testImplementation("software.amazon.awssdk:aws-core:2.31.32")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
     testImplementation("org.mockito:mockito-junit-jupiter:5.1.1")
+    testImplementation("software.amazon.awssdk:regions:2.33.8")
 
-    // Runtime dependencies
+    // Runtime dependencies for tests
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/software/amazon/dsql/jdbc/PropertyUtils.java
+++ b/src/main/java/software/amazon/dsql/jdbc/PropertyUtils.java
@@ -16,8 +16,7 @@
 
 package software.amazon.dsql.jdbc;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
+import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -29,7 +28,7 @@ public final class PropertyUtils {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 
-    public static @NonNull Properties copyProperties(final Properties props) {
+    public static @Nonnull Properties copyProperties(final Properties props) {
         final Properties copy = new Properties();
 
         if (props == null) {
@@ -39,7 +38,7 @@ public final class PropertyUtils {
         return addProperties(copy, props);
     }
 
-    public static @NonNull Properties addProperties(
+    public static @Nonnull Properties addProperties(
             final Properties dest, final Properties propsToAdd) {
 
         if (dest == null) {


### PR DESCRIPTION
This PR updates the Gradle dependencies to the latest versions.

The `javax.annotation-api` dependency is not needed since they are provided by the `spotbugs-annotations` library.

This PR is currently based on #13, but will be swapped to target `main` once the dependency has been merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
