### PR TITLE
Avoid explicit version reference in source

### DIFF
--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -153,6 +153,7 @@ jobs:
     - name: Run integration tests
       working-directory: integration-tests
       env:
+        PROJECT_VERSION: 0.0.0-SNAPSHOT
         REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
         CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-id }}.dsql.${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}.on.aws
         CLUSTER_USER: "admin"

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -2,7 +2,6 @@ name: Deploy to Maven Central
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   deploy:
@@ -20,10 +19,12 @@ jobs:
           distribution: 'corretto'
       - name: Deploy to Central Portal
         run: |
+          echo "Publishing version: $PROJECT_VERSION"
           ./gradlew build
           ./gradlew publish
           ./gradlew jreleaserDeploy
         env:
+          PROJECT_VERSION: ${{ github.event.release.tag_name }}
           JRELEASER_MAVENCENTRAL_STAGE: 'UPLOAD'
           JRELEASER_GPG_PUBLIC_KEY: |
             ${{ secrets.GPG_PUBLIC_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 }
 
 group = "software.amazon.dsql"
+version = System.getenv("PROJECT_VERSION") ?: "0.0.0-SNAPSHOT"
 
 val targetJavaVersion = project.property("targetJavaVersion").toString().toInt()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-version=1.0.0
 targetJavaVersion=8

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import java.util.Properties
-
 plugins {
     id("java")
 }
@@ -12,14 +10,13 @@ repositories {
     mavenCentral()
 }
 
-val parentProps =
-    Properties().apply {
-        load(file("../gradle.properties").inputStream())
-    }
-
 dependencies {
-    // Define dependency this way to allow for independent execution of tests with a pre-built jar.
-    testImplementation("software.amazon.dsql:aurora-dsql-jdbc-connector:${parentProps["version"]}")
+    // Allow subproject to build standalone if the dependency is published in mavenLocal.
+    if (System.getenv("PROJECT_VERSION") != null) {
+        testImplementation("software.amazon.dsql:aurora-dsql-jdbc-connector:${System.getenv("PROJECT_VERSION")}")
+    } else {
+        testImplementation(project(":"))
+    }
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
This PR removes the explicit `version` property from the project.

This is likely to fall out of sync with the GitHub release version, given we would need to keep them synchronized manually. It seems easy to use a development version for the source code, and inject the release version during the release workflow.

Any development builds will use `0.0.0-SNAPSHOT` which is clearly not a publishable version, and the version will only be provided by the GithHub release process.

This PR is currently based on #15, but will be swapped to target `main` once the dependency has been merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
