### PR TITLE
Remove version number references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ This project uses Gradle 8.13 and follows the same build patterns as other AWS A
 ### Build Artifacts
 
 The build generates the following artifacts:
-- Main library JAR
-- Source code JAR
-- Javadoc JAR
+- `aurora-dsql-jdbc-connector-<VERSION>.jar` - Main library JAR
+- `aurora-dsql-jdbc-connector-<VERSION>-sources.jar` - Source code JAR
+- `aurora-dsql-jdbc-connector-<VERSION>-javadoc.jar` - Javadoc JAR
 
 ### Code Quality
 


### PR DESCRIPTION
This PR removes references to the current `1.0.0` version number from the `README.md` file.

We already have a badge at the top of the `README.md` which is automatically updated from Maven Central. Having explicit version numbers in the docs (and especially so many) will make it likely that the version number will fall out of sync when new versions are released. We could set up automation to address this but it's not really necessary given we can defer to Maven Central.

This follows on from #16.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
