### PR TITLE
Fix publish workflow JDK version

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -12,10 +12,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '24'
           distribution: 'corretto'
       - name: Deploy to Central Portal
         run: |


### PR DESCRIPTION
While attempting to release v1.1.0, the release workflow failed due to still referencing the old JDK version. This PR updates the JDK version used by the workflow to match the project requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
