### PR TITLE
Use explicit mavenLocal env var for standalone integration tests

### DIFF
--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -154,6 +154,7 @@ jobs:
       working-directory: integration-tests
       env:
         USE_MAVEN_LOCAL: "true"
+        PROJECT_VERSION: 0.0.0-SNAPSHOT
         REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
         CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-id }}.dsql.${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}.on.aws
         CLUSTER_USER: "admin"

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -153,7 +153,7 @@ jobs:
     - name: Run integration tests
       working-directory: integration-tests
       env:
-        PROJECT_VERSION: 0.0.0-SNAPSHOT
+        USE_MAVEN_LOCAL: "true"
         REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
         CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-id }}.dsql.${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}.on.aws
         CLUSTER_USER: "admin"

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // Allow subproject to build standalone if the dependency is published in mavenLocal.
-    if (System.getenv("PROJECT_VERSION") != null) {
+    if (System.getenv("USE_MAVEN_LOCAL") != null) {
         testImplementation("software.amazon.dsql:aurora-dsql-jdbc-connector:${System.getenv("PROJECT_VERSION")}")
     } else {
         testImplementation(project(":"))


### PR DESCRIPTION
This PR fixes an issue with the publish workflow, where it tries to build the integration tests using the released version number which has not been published yet.

In #11 and #16 I made changes to allow the integration tests to run as a standalone Gradle project. This is necessary for the matrix testing which tests the integration tests against a number of different JVM versions. Unfortunately the approach here is not completely compatible with the release workflow, since the `PROJECT_VERSION` variable is set there and the workflow attempts to build the integration tests against a `.jar` file which has not yet been published.

To fix this, I've split the intent configuration from the version configuration. Now the `USE_MAVEN_LOCAL` variable indicates that a standalone build should take place, and `PROJECT_VERSION` is used to configure the `.jar` file to look for as well as to configure the version number for the project build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
