### PR TITLE
Embed dynamic version number in jar file

### DIFF
--- a/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
+++ b/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
@@ -171,12 +171,30 @@ public class DSQLConnector implements java.sql.Driver {
 
     @Override
     public int getMajorVersion() {
-        return 1;
+        return Version.MAJOR;
     }
 
     @Override
     public int getMinorVersion() {
-        return 0;
+        return Version.MINOR;
+    }
+
+    /**
+     * Provides the patch version of this driver.
+     *
+     * @return the patch version number
+     */
+    public int getPatchVersion() {
+        return Version.PATCH;
+    }
+
+    /**
+     * Provides the full version string of this driver (e.g., "1.2.3" or "1.2.3-SNAPSHOT").
+     *
+     * @return the full version string
+     */
+    public String getVersion() {
+        return Version.FULL;
     }
 
     @Override

--- a/src/test/java/software/amazon/dsql/jdbc/DSQLConnectorTest.java
+++ b/src/test/java/software/amazon/dsql/jdbc/DSQLConnectorTest.java
@@ -415,12 +415,22 @@ class DSQLConnectorTest {
 
     @Test
     void testGetMajorVersion() {
-        assertEquals(1, driver.getMajorVersion());
+        assertEquals(Version.MAJOR, driver.getMajorVersion());
     }
 
     @Test
     void testGetMinorVersion() {
-        assertEquals(0, driver.getMinorVersion());
+        assertEquals(Version.MINOR, driver.getMinorVersion());
+    }
+
+    @Test
+    void testGetPatchVersion() {
+        assertEquals(Version.PATCH, driver.getPatchVersion());
+    }
+
+    @Test
+    void testGetDriverVersion() {
+        assertEquals(Version.FULL, driver.getVersion());
     }
 
     @Test


### PR DESCRIPTION
This PR generates a `Version` class during the build to capture the current version number, and provide it at runtime.

I noticed that [this method](https://javadoc.io/static/software.amazon.dsql/aurora-dsql-jdbc-connector/1.1.0/software/amazon/dsql/jdbc/DSQLConnector.html#getMajorVersion()) is provided by the library, which was previously hard coded. It should have been updated as part of #16 but was missed. The current release `1.1.0` artifact is indicating it is `1.0.*` as a result.

I also added methods to return the patch version and full version string since they are available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
