### PR TITLE
Add javadoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Aurora DSQL JDBC Connector
 [![Maven Central Version](https://img.shields.io/maven-central/v/software.amazon.dsql/aurora-dsql-jdbc-connector?style=for-the-badge)](https://central.sonatype.com/artifact/software.amazon.dsql/aurora-dsql-jdbc-connector)
+[![Javadoc](https://img.shields.io/badge/javadoc-latest-blue.svg?style=for-the-badge)](https://javadoc.io/doc/software.amazon.dsql/aurora-dsql-jdbc-connector/latest/software/amazon/dsql/jdbc/package-summary.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge)](LICENSE)
 
 A PgJDBC connector that integrates IAM Authentication for connecting Java applications to Amazon Aurora DSQL clusters.


### PR DESCRIPTION
This PR adds a badge which links to the latest Javadoc for the library. This makes it simpler for users to find the more detailed documentation for the library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
