### PR TITLE
Minimize workflow permissions

### DIFF
--- a/.github/workflows/gitleaks-scan.yml
+++ b/.github/workflows/gitleaks-scan.yml
@@ -1,5 +1,7 @@
 name: Gitleaks scan
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]
@@ -9,14 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      # Explicitly set permissions, following the principle of least privilege
-      actions: read
-      checks: write
-      pull-requests: write
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -1,7 +1,6 @@
 name: Aurora DSQL JDBC Connector Tests
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -89,7 +88,7 @@ jobs:
     needs: [setup, unit-tests]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # required by aws-actions/configure-aws-credentials
     outputs:
       cluster-id: ${{ steps.create.outputs.cluster-id }}
     steps:
@@ -119,7 +118,7 @@ jobs:
     needs: [setup, create-cluster]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # required by aws-actions/configure-aws-credentials
     strategy:
       max-parallel: 1
       fail-fast: true
@@ -167,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && needs.create-cluster.result == 'success'
     permissions:
-      id-token: write
+      id-token: write # required by aws-actions/configure-aws-credentials
     steps:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,4 +1,7 @@
 name: Deploy to Maven Central
+
+permissions: {}
+
 on:
   release:
     types: [published]
@@ -6,10 +9,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 24


### PR DESCRIPTION
This PR minimizes the permissions granted to the GitHub workflows, and documents why the granted ones are required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
