### PR TITLE
Fix database property parsing

### DIFF
--- a/src/main/java/software/amazon/dsql/jdbc/ConnUrlParser.java
+++ b/src/main/java/software/amazon/dsql/jdbc/ConnUrlParser.java
@@ -47,13 +47,19 @@ public final class ConnUrlParser {
             return;
         }
 
-        final String cleanUrl = url.substring(5);
-        final URI connUrl = new URI(cleanUrl);
+        final String cleanUrl;
+        if (url.startsWith(CONNECTOR_POSTGRESQL_PREFIX)) {
+            cleanUrl = url.substring(CONNECTOR_POSTGRESQL_PREFIX.length());
+        } else if (url.startsWith(JDBC_PREFIX)) {
+            cleanUrl = url.substring(JDBC_PREFIX.length());
+        } else {
+            cleanUrl = url.substring(5); // fallback: strip "jdbc:"
+        }
 
-        // Extract database name from path if present and not already set in properties
-        if (props.getProperty("database") == null
-                && connUrl.getPath() != null
-                && !connUrl.getPath().isEmpty()) {
+        final URI connUrl = new URI("postgresql://" + cleanUrl);
+
+        // Extract database name from path if present
+        if (connUrl.getPath() != null && !connUrl.getPath().isEmpty()) {
             final String database = connUrl.getPath().substring(1); // Remove leading '/'
             props.setProperty("database", database);
         }
@@ -66,6 +72,12 @@ public final class ConnUrlParser {
         final String[] listOfParameters = params.split("&");
         for (final String param : listOfParameters) {
             final String[] keyValPair = param.split("=");
+
+            if (keyValPair[0].equals("database")) {
+                throw new URISyntaxException(
+                        url,
+                        "database must be specified in the URL path, not as a query parameter");
+            }
 
             if (keyValPair.length == 1) {
                 props.setProperty(keyValPair[0], "");


### PR DESCRIPTION
This PR fixes the handling of the database property in the connection URL.

There was some handling around this previously, but its behavior didn't match the semantics defined for the other properties, and there wasn't much testing around it. I've fixed the semantics so all properties match, and added more robust tests including a new integration test.

The changes include:
- Update the provided `Properties` object with the database in `parsePropertiesFromUrl`
- Matching semantics for database property where URL property overrides `Properties` object
- Throw exception if `database=` URL query parameter property is defined since it's invalid and ambiguous (`psql` rejects it too)
- Make `parsePropertiesFromUrl` more robust to other URL prefix formats, which was needed for the tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
