### PR TITLE
Fix logger package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The connector uses Java's built-in logging system (java.util.logging). You can c
 .level = INFO
 
 # Show Aurora DSQL JDBC Connector FINE logs for detailed debugging
-software.amazon.dsql.level = FINE
+software.amazon.dsql.jdbc.level = FINE
 
 # Console handler configuration
 handlers = java.util.logging.ConsoleHandler

--- a/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
+++ b/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
@@ -75,8 +75,9 @@ import software.amazon.awssdk.regions.Region;
  */
 public class DSQLConnector implements java.sql.Driver {
 
-    private static final Logger PARENT_LOGGER = Logger.getLogger("software.amazon.dsql.jdbc");
-    private static final Logger LOGGER = Logger.getLogger("com.amazon.jdbc.DSQLConnector");
+    private static final Logger PARENT_LOGGER =
+            Logger.getLogger(DSQLConnector.class.getPackage().getName());
+
     private static @Nullable Driver registeredDriver;
 
     static {

--- a/src/main/java/software/amazon/dsql/jdbc/PropertyDefinition.java
+++ b/src/main/java/software/amazon/dsql/jdbc/PropertyDefinition.java
@@ -71,7 +71,7 @@ public final class PropertyDefinition {
                 "This is a utility class and cannot be instantiated");
     }
 
-    private static final Logger LOGGER = Logger.getLogger("com.amazon.jdbc.PropertyDefinition");
+    private static final Logger LOGGER = Logger.getLogger(PropertyDefinition.class.getName());
 
     /**
      * Database user for authentication.


### PR DESCRIPTION
This PR fixes the package names used by the `Logger` instances in the project.

Previously, they were using inconsistent package names that appear to have been from some previous (never published) package version. Instead of the published package name (`software.amazon.dsql.jdbc`) some of the `Logger` instances used `om.amazon.jdbc`.

I've made sure that all `Logger` instances use `MyClass.class.getName()` to avoid discrepancies, and ease future maintenance. I also updated the `PARENT_LOGGER` to reference the package name programatically to avoid the same issue. `LOGGER` is no longer defined in the `DSQLConnector` class as it was not used and can easily be added later.

I noticed the `README.md` recommended configuring the log level of `software.amazon.dsql`, but that could potentially affect other packages in the parent namespace. I've updated the description there to reference the package name of this library.

This PR is currently stacked on #28, but will be merged to `main` once the dependency is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
